### PR TITLE
Fix keystream expansion

### DIFF
--- a/Duey.sln
+++ b/Duey.sln
@@ -1,4 +1,4 @@
-﻿
+
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
 VisualStudioVersion = 15.0.26124.0
@@ -13,6 +13,8 @@ EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Duey.Abstractions", "src\Duey.Abstractions\Duey.Abstractions.csproj", "{648311E4-DFF6-40D3-AB49-D85B7BE036A2}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Duey.Provider.WZ", "src\Duey.Provider.WZ\Duey.Provider.WZ.csproj", "{6EC8524D-B087-4003-B25C-253EDB42F615}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Duey.Provider.WZ.Tests", "tests\Duey.Provider.WZ.Tests\Duey.Provider.WZ.Tests.csproj", "{8B0C9E12-4DA2-4E3F-8E49-3E5B7604D7F3}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -63,6 +65,18 @@ Global
 		{6EC8524D-B087-4003-B25C-253EDB42F615}.Release|x64.Build.0 = Release|Any CPU
 		{6EC8524D-B087-4003-B25C-253EDB42F615}.Release|x86.ActiveCfg = Release|Any CPU
 		{6EC8524D-B087-4003-B25C-253EDB42F615}.Release|x86.Build.0 = Release|Any CPU
+		{8B0C9E12-4DA2-4E3F-8E49-3E5B7604D7F3}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{8B0C9E12-4DA2-4E3F-8E49-3E5B7604D7F3}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{8B0C9E12-4DA2-4E3F-8E49-3E5B7604D7F3}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{8B0C9E12-4DA2-4E3F-8E49-3E5B7604D7F3}.Debug|x64.Build.0 = Debug|Any CPU
+		{8B0C9E12-4DA2-4E3F-8E49-3E5B7604D7F3}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{8B0C9E12-4DA2-4E3F-8E49-3E5B7604D7F3}.Debug|x86.Build.0 = Debug|Any CPU
+		{8B0C9E12-4DA2-4E3F-8E49-3E5B7604D7F3}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{8B0C9E12-4DA2-4E3F-8E49-3E5B7604D7F3}.Release|Any CPU.Build.0 = Release|Any CPU
+		{8B0C9E12-4DA2-4E3F-8E49-3E5B7604D7F3}.Release|x64.ActiveCfg = Release|Any CPU
+		{8B0C9E12-4DA2-4E3F-8E49-3E5B7604D7F3}.Release|x64.Build.0 = Release|Any CPU
+		{8B0C9E12-4DA2-4E3F-8E49-3E5B7604D7F3}.Release|x86.ActiveCfg = Release|Any CPU
+		{8B0C9E12-4DA2-4E3F-8E49-3E5B7604D7F3}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 		{CB853B65-1455-4A28-BF23-B903161DBEA5} = {19B8D1C2-E056-4BE2-98CE-59269DC3182B}

--- a/src/Duey.Provider.WZ/Crypto/AESCipher.cs
+++ b/src/Duey.Provider.WZ/Crypto/AESCipher.cs
@@ -1,10 +1,12 @@
-using System.Security.Cryptography;
 using Duey.Provider.WZ.Files;
+using System.Security.Cryptography;
 
 namespace Duey.Provider.WZ.Crypto;
 
 public class AESCipher
 {
+    private const int DefaultKeySize = 256;
+    private const int DefaultBlockSize = 16;
     private readonly ICryptoTransform _transformer;
 
     public AESCipher() : this(WZImageKey.Default)
@@ -14,17 +16,27 @@ public class AESCipher
     public AESCipher(ReadOnlySpan<byte> userKey)
     {
         var expandedKey = new byte[userKey.Length * 4];
-        var cipher = Aes.Create();
+        var cipher = Aes.Create() ?? throw new InvalidOperationException("AES provider not available");
 
         for (var i = 0; i < userKey.Length; i++)
             expandedKey[i * 4] = userKey[i];
 
-        cipher.KeySize = 256;
+        cipher.KeySize = DefaultKeySize;
         cipher.Key = expandedKey;
         cipher.Mode = CipherMode.ECB;
+        cipher.Padding = PaddingMode.None;
         _transformer = cipher.CreateEncryptor();
     }
 
     public byte[] Transform(byte[] input)
-        => _transformer.TransformFinalBlock(input, 0, input.Length);
+    {
+        if (input.Length % DefaultBlockSize != 0)
+            throw new ArgumentException($"Input length must be a multiple of {DefaultBlockSize} bytes", nameof(input));
+
+        var output = new byte[input.Length];
+        for (var offset = 0; offset < input.Length; offset += DefaultBlockSize)
+            _transformer.TransformBlock(input, offset, DefaultBlockSize, output, offset);
+
+        return output;
+    }
 }

--- a/tests/Duey.Provider.WZ.Tests/Duey.Provider.WZ.Tests.csproj
+++ b/tests/Duey.Provider.WZ.Tests/Duey.Provider.WZ.Tests.csproj
@@ -1,0 +1,23 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="xunit" Version="2.6.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.5">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Duey.Provider.WZ\Duey.Provider.WZ.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/tests/Duey.Provider.WZ.Tests/KeystreamExpansionTests.cs
+++ b/tests/Duey.Provider.WZ.Tests/KeystreamExpansionTests.cs
@@ -1,0 +1,46 @@
+using Duey.Provider.WZ.Crypto;
+using Duey.Provider.WZ.Files;
+using Xunit;
+
+namespace Duey.Provider.WZ.Tests;
+
+public class KeystreamExpansionTests
+{
+    private static readonly byte[] FullExpectedKeystream = Convert.FromHexString(
+        "96AE3FA448FADD904676056197CE7868" +
+        "2BA0448FC1567E32FCE1F5B31414C522" +
+        "F5C3682E9DC34A0BFAFE6845538AFB5D" +
+        "094F59FCE911129BD90FF2E862693B76" +
+        "47881075ACE396D7DB1279CD59E4E00C"
+    );
+
+    [Theory]
+    [InlineData(64)]
+    [InlineData(80)]
+    public void Expansion_MatchesExpected(int length)
+    {
+        var cipher = new XORCipher(WZImageIV.GMS);
+        var data = new byte[length];
+
+        cipher.Transform(data);
+
+        var expected = FullExpectedKeystream.AsSpan(0, length);
+
+        Assert.True(data.AsSpan().SequenceEqual(expected), $"Keystream mismatch at length {length}");
+    }
+
+    [Fact]
+    public void ExpansionDoesNotContainPkcs7PaddingBlock()
+    {
+        var cipher = new XORCipher(WZImageIV.GMS);
+        var data = new byte[64];
+
+        cipher.Transform(data);
+
+        ReadOnlySpan<byte> pkcs7Block = Convert.FromHexString("15BEA7702C0A428F9CBC0C2909C85135");
+
+        var index = data.AsSpan().IndexOf(pkcs7Block);
+
+        Assert.True(index == -1, "The expansion should not contain the PKCS7 padding block.");
+    }
+}


### PR DESCRIPTION
Fixes: #4 

The AES cipher implementation in the WZ provider uses PKCS7 padding by default when calling `TransformFinalBlock`, which produces 32 bytes of output for a 16-byte block. The second 16 bytes (padding block) incorrectly becomes "block1" in the keystream expansion, causing all subsequent blocks to be derived from wrong input.

Now correctly displays the expected result:
<img width="1222" height="190" alt="image" src="https://github.com/user-attachments/assets/ac314bd2-13d5-45c2-94fc-0662031f4bb8" />
