### PR TITLE
Fix WZ variant parsing alignment for BoolVariant and 64-bit types

### DIFF
--- a/src/Duey.Provider.WZ/Files/WZPropertyFile.cs
+++ b/src/Duey.Provider.WZ/Files/WZPropertyFile.cs
@@ -64,8 +64,10 @@ public class WZPropertyFile : AbstractWZNode, IDataNode
                         yield return new WZPropertyData<long>(name, this, reader.ReadUInt16());
                         break;
                     case WZVariantType.Int16Variant:
-                    case WZVariantType.BoolVariant:
                         yield return new WZPropertyData<long>(name, this, reader.ReadInt16());
+                        break;
+                    case WZVariantType.BoolVariant:
+                        yield return new WZPropertyData<long>(name, this, reader.ReadByte());
                         break;
                     case WZVariantType.Uint32Variant:
                     case WZVariantType.Int32Variant:
@@ -86,7 +88,7 @@ public class WZPropertyFile : AbstractWZNode, IDataNode
                     case WZVariantType.CYVariant:
                     case WZVariantType.Int64Variant:
                     case WZVariantType.Uint64Variant:
-                        yield return new WZPropertyData<long>(name, this, reader.ReadCompressedLong());
+                        yield return new WZPropertyData<long>(name, this, reader.ReadInt64());
                         break;
                     case WZVariantType.DispatchVariant:
                     case WZVariantType.UnknownVariant:

--- a/tests/Duey.Provider.WZ.Tests/VariantParsingTests.cs
+++ b/tests/Duey.Provider.WZ.Tests/VariantParsingTests.cs
@@ -1,0 +1,240 @@
+using System.IO.MemoryMappedFiles;
+using System.Text;
+using Duey.Provider.WZ.Crypto;
+using Duey.Provider.WZ.Files;
+using Duey.Provider.WZ.Types;
+using Xunit;
+
+namespace Duey.Provider.WZ.Tests;
+
+/// <summary>
+/// Tests that verify correct byte consumption for WZ variant types.
+///
+/// When a variant type consumes the wrong number of bytes, the stream
+/// desynchronizes and subsequent ReadStringBlock() calls encounter
+/// invalid type bytes, causing "Unknown string type when reading string block"
+/// exceptions. This is the root cause of Canvas/Property parsing failures
+/// in archives like Map.wz.
+/// </summary>
+public class VariantParsingTests
+{
+    /// <summary>
+    /// BoolVariant (type 11) must consume exactly 1 byte, not 2.
+    ///
+    /// When incorrectly grouped with Int16Variant and read via ReadInt16() (2 bytes),
+    /// the stream advances 1 byte too far. The next property's string block type byte
+    /// becomes 0xFF (the negative ASCII length marker of the following name), which is
+    /// not a valid string block type (0x00, 0x73, 0x01, 0x1B), causing
+    /// WZPackageException: "Unknown string type when reading string block".
+    ///
+    /// Binary layout:
+    ///   [header 3B] [empty name 2B] [type 0x0B 1B] [value 0x01 1B]
+    ///                                               ↑ correct: 1 byte
+    ///                                               ↑ bug: 2 bytes (reads into next name)
+    ///   [name "x" 4B] [type 0x09 1B] [size 4B] [Canvas string block 8B] [pad]
+    ///    ↑ offset 7 (correct) or offset 8 (bug: hits 0xFF → unknown type)
+    /// </summary>
+    [Fact]
+    public void BoolVariant_ConsumesOneByte_CanvasEntryParsedCorrectly()
+    {
+        var cipher = new XORCipher(WZImageIV.GMS);
+        var data = BuildBoolVariantTestData(cipher);
+
+        using var mmf = CreateMemoryMappedFile(data);
+        var prop = new WZPropertyFile(mmf, cipher, start: 0, offset: 0, name: "test");
+
+        var children = prop.Children.ToList();
+
+        Assert.Equal(2, children.Count);
+    }
+
+    /// <summary>
+    /// CYVariant (type 6) must consume exactly 8 bytes (fixed Int64), not a
+    /// compressed long (1 or 9 bytes).
+    ///
+    /// The test value 0xFF00 has little-endian bytes [0x00, 0xFF, ...].
+    /// With ReadCompressedLong (bug): reads sbyte 0x00 (not -128), returns 0,
+    /// consumes only 1 byte → 7-byte misalignment → next string block type is
+    /// 0xFF → "Unknown string type".
+    /// With ReadInt64 (fix): consumes all 8 bytes → stream stays aligned.
+    /// </summary>
+    [Fact]
+    public void CYVariant_ConsumesEightFixedBytes_NextPropertyParsedCorrectly()
+    {
+        var cipher = new XORCipher(WZImageIV.GMS);
+        var data = Build64BitVariantTestData(cipher, WZVariantType.CYVariant);
+
+        using var mmf = CreateMemoryMappedFile(data);
+        var prop = new WZPropertyFile(mmf, cipher, start: 0, offset: 0, name: "test");
+
+        var children = prop.Children.ToList();
+
+        Assert.Equal(2, children.Count);
+    }
+
+    /// <summary>
+    /// Int64Variant (type 20) must consume exactly 8 bytes (fixed Int64),
+    /// not a compressed long.
+    /// </summary>
+    [Fact]
+    public void Int64Variant_ConsumesEightFixedBytes_NextPropertyParsedCorrectly()
+    {
+        var cipher = new XORCipher(WZImageIV.GMS);
+        var data = Build64BitVariantTestData(cipher, WZVariantType.Int64Variant);
+
+        using var mmf = CreateMemoryMappedFile(data);
+        var prop = new WZPropertyFile(mmf, cipher, start: 0, offset: 0, name: "test");
+
+        var children = prop.Children.ToList();
+
+        Assert.Equal(2, children.Count);
+    }
+
+    /// <summary>
+    /// Uint64Variant (type 21) must consume exactly 8 bytes (fixed Int64),
+    /// not a compressed long.
+    /// </summary>
+    [Fact]
+    public void Uint64Variant_ConsumesEightFixedBytes_NextPropertyParsedCorrectly()
+    {
+        var cipher = new XORCipher(WZImageIV.GMS);
+        var data = Build64BitVariantTestData(cipher, WZVariantType.Uint64Variant);
+
+        using var mmf = CreateMemoryMappedFile(data);
+        var prop = new WZPropertyFile(mmf, cipher, start: 0, offset: 0, name: "test");
+
+        var children = prop.Children.ToList();
+
+        Assert.Equal(2, children.Count);
+    }
+
+    // ── Helpers ──────────────────────────────────────────────────────────
+
+    private static MemoryMappedFile CreateMemoryMappedFile(byte[] data)
+    {
+        var mmf = MemoryMappedFile.CreateNew(null, data.Length);
+        using var stream = mmf.CreateViewStream(0, data.Length, MemoryMappedFileAccess.Write);
+        stream.Write(data, 0, data.Length);
+        return mmf;
+    }
+
+    /// <summary>
+    /// Builds: [BoolVariant, value=1] + [DispatchVariant/Canvas].
+    /// A 2-byte BoolVariant read shifts the stream so the next string block
+    /// type byte lands on 0xFF, triggering "Unknown string type".
+    /// </summary>
+    private static byte[] BuildBoolVariantTestData(XORCipher cipher)
+    {
+        using var ms = new MemoryStream();
+        using var writer = new BinaryWriter(ms);
+
+        // Property header
+        writer.Write(false); // first boolean
+        writer.Write(false); // second boolean (false → don't skip 2 bytes)
+        writer.Write((sbyte)2); // compressed int count = 2
+
+        // Property 0: BoolVariant with empty name
+        WriteInlineStringBlock(writer, "", cipher);
+        writer.Write((byte)WZVariantType.BoolVariant);
+        writer.Write((byte)1); // value = true (1 byte)
+
+        // Property 1: DispatchVariant("Canvas") with name "x"
+        // Name "x" starts with 0x00 (inline type) then 0xFF (-1 as sbyte = ASCII 1 char).
+        // Off-by-one bug: reader lands on the 0xFF byte and treats it as string block type.
+        WriteInlineStringBlock(writer, "x", cipher);
+        writer.Write((byte)WZVariantType.DispatchVariant);
+
+        var sizePosition = ms.Position;
+        writer.Write(0); // size placeholder
+        var contentStart = ms.Position;
+
+        WriteInlineStringBlock(writer, "Canvas", cipher);
+
+        var contentSize = (int)(ms.Position - contentStart);
+
+        // Padding so position + size lands in valid area
+        var padding = new byte[64];
+        writer.Write(padding);
+
+        // Patch size field
+        ms.Position = sizePosition;
+        writer.Write(contentSize + padding.Length);
+
+        return PadToMinimumSize(ms.ToArray(), 256);
+    }
+
+    /// <summary>
+    /// Builds: [64-bit variant, value=0xFF00] + [Int32Variant, value=42].
+    /// Value 0xFF00 in little-endian is [0x00, 0xFF, 0x00, ...].
+    /// ReadCompressedLong reads sbyte 0x00 (not -128) → consumes only 1 byte → 7-byte drift.
+    /// The reader then hits 0xFF as string block type → "Unknown string type".
+    /// </summary>
+    private static byte[] Build64BitVariantTestData(XORCipher cipher, WZVariantType variantType)
+    {
+        using var ms = new MemoryStream();
+        using var writer = new BinaryWriter(ms);
+
+        // Property header
+        writer.Write(false);
+        writer.Write(false);
+        writer.Write((sbyte)2); // count = 2
+
+        // Property 0: 64-bit variant with empty name
+        WriteInlineStringBlock(writer, "", cipher);
+        writer.Write((byte)variantType);
+        writer.Write(0xFF00L); // 8 bytes LE: [0x00, 0xFF, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00]
+
+        // Property 1: Int32Variant with name "x"
+        WriteInlineStringBlock(writer, "x", cipher);
+        writer.Write((byte)WZVariantType.Int32Variant);
+        writer.Write((sbyte)42); // compressed int value = 42
+
+        return PadToMinimumSize(ms.ToArray(), 256);
+    }
+
+    /// <summary>
+    /// Writes an inline string block (type 0x00) with ASCII encoding.
+    /// Encrypts the string content using the same XOR mask + cipher pipeline
+    /// that WZReader.ReadString/ReadStringASCII uses for decryption.
+    /// </summary>
+    private static void WriteInlineStringBlock(BinaryWriter writer, string value, XORCipher cipher)
+    {
+        writer.Write((byte)0x00); // string block type: inline
+
+        if (string.IsNullOrEmpty(value))
+        {
+            writer.Write((sbyte)0); // length = 0 → empty string
+            return;
+        }
+
+        var plaintext = Encoding.ASCII.GetBytes(value);
+        writer.Write((sbyte)(-plaintext.Length)); // negative length = ASCII
+
+        // Encrypt: reverse of WZReader decryption pipeline
+        // Decryption: raw → XOR mask (0xAA+i) → cipher XOR keystream → plaintext
+        // Encryption: plaintext → cipher XOR keystream → XOR mask (0xAA+i) → raw
+        var encrypted = new byte[plaintext.Length];
+        Buffer.BlockCopy(plaintext, 0, encrypted, 0, plaintext.Length);
+
+        cipher.Transform(encrypted);
+
+        byte mask = 0xAA;
+        for (var i = 0; i < encrypted.Length; i++)
+        {
+            encrypted[i] ^= mask;
+            mask++;
+        }
+
+        writer.Write(encrypted);
+    }
+
+    private static byte[] PadToMinimumSize(byte[] data, int minSize)
+    {
+        if (data.Length >= minSize)
+            return data;
+
+        var padded = new byte[minSize];
+        Buffer.BlockCopy(data, 0, padded, 0, data.Length);
+        return padded;
+    }
+}


### PR DESCRIPTION
# Summary

Fixes stream desynchronization in `WZPropertyFile.Children` that caused `WZPackageException: Unknown string type when reading string block` when parsing archives containing Canvas properties (e.g., `Map.wz`).

Two variant type groups consumed the wrong number of bytes from the binary stream, causing cascading parse failures on all subsequent properties. The correct byte widths were determined by reverse engineering the v95 client and validated against actual Map.wz parsing via the Duey2Test diagnostic framework.

## Root cause: COM VARIANT layout vs WZ wire format

The WZ format uses the COM `VARTYPE` enum (from `oaidl.h`) for variant type IDs, but the **wire format** (serialization to disk) differs from the COM **in-memory** `VARIANT` layout:

- **VT_BOOL (0x0B)**: In COM memory, `VARIANT_BOOL` = `short` (2 bytes). In WZ wire format: **1 byte**. Duey used `ReadInt16()` matching COM memory, but the wire format stores a single byte.

- **VT_CY/VT_I8/VT_UI8**: The WZ format uses a sentinel-based compression (`ReadCompressedInt`) for `VT_I4` (Int32), where sbyte -128 means "full 4-byte value follows." Duey applied the same compression to 64-bit types via `ReadCompressedLong()`. But the WZ wire format stores these as **fixed 8-byte values** without compression.

The client disassembly confirms the 1:1 mapping between `VARTYPE` enum values and Duey's `WZVariantType`, while the diagnostic walker's proven-correct parsing table establishes the wire format byte widths.

## Changes

### `src/Duey.Provider.WZ/Files/WZPropertyFile.cs`

**BoolVariant (VT_BOOL, type 11):** Separated from `Int16Variant` — `ReadInt16()` (2B) to `ReadByte()` (1B).

```diff
  case WZVariantType.Int16Variant:
- case WZVariantType.BoolVariant:
      yield return new WZPropertyData<long>(name, this, reader.ReadInt16());
      break;
+ case WZVariantType.BoolVariant:
+     yield return new WZPropertyData<long>(name, this, reader.ReadByte());
+     break;
```

**CYVariant/Int64Variant/Uint64Variant (VT_CY/VT_I8/VT_UI8, types 6, 20, 21):** `ReadCompressedLong()` (1-9B) to `ReadInt64()` (fixed 8B).

```diff
  case WZVariantType.CYVariant:
  case WZVariantType.Int64Variant:
  case WZVariantType.Uint64Variant:
-     yield return new WZPropertyData<long>(name, this, reader.ReadCompressedLong());
+     yield return new WZPropertyData<long>(name, this, reader.ReadInt64());
      break;
```

### `tests/Duey.Provider.WZ.Tests/VariantParsingTests.cs` (new)

4 tests constructing synthetic WZ property blocks that verify correct byte consumption:

| Test | Verifies |
|---|---|
| `BoolVariant_ConsumesOneByte_CanvasEntryParsedCorrectly` | BoolVariant reads 1 byte; Canvas entry following it is reachable |
| `CYVariant_ConsumesEightFixedBytes_NextPropertyParsedCorrectly` | CYVariant reads 8 fixed bytes; next property is parseable |
| `Int64Variant_ConsumesEightFixedBytes_NextPropertyParsedCorrectly` | Int64Variant reads 8 fixed bytes |
| `Uint64Variant_ConsumesEightFixedBytes_NextPropertyParsedCorrectly` | Uint64Variant reads 8 fixed bytes |

Each test crafts binary data where a misaligned read causes the next `ReadStringBlock()` to hit byte 0xFF (not a valid string block type), producing the exact `WZPackageException` seen in production. Before the fix, all 4 tests fail. After the fix, all pass.

## WZ compression patterns reference

For context, the full WZ variant serialization table (wire format), as established by client RE and diagnostic validation:

| COM Type | WZ Variant | Wire Format | Read Method | Bytes |
|---|---|---|---|---|
| VT_EMPTY (0) | EmptyVariant | — | skip | 0 |
| VT_I1 (16) | Int8Variant | fixed | `ReadSByte()` | 1 |
| VT_UI1 (17) | Uint8Variant | fixed | `ReadByte()` | 1 |
| VT_BOOL (11) | BoolVariant | fixed | `ReadByte()` | 1 |
| VT_I2 (2) | Int16Variant | fixed | `ReadInt16()` | 2 |
| VT_UI2 (18) | Uint16Variant | fixed | `ReadUInt16()` | 2 |
| VT_I4 (3) | Int32Variant | **compressed** | `ReadCompressedInt()` | 1 or 5 |
| VT_UI4 (19) | Uint32Variant | **compressed** | `ReadCompressedInt()` | 1 or 5 |
| VT_R4 (4) | Float32Variant | **sentinel** | sbyte; if -128 → `ReadSingle()` | 1 or 5 |
| VT_R8 (5) | Float64Variant | fixed | `ReadDouble()` | 8 |
| VT_CY (6) | CYVariant | fixed | `ReadInt64()` | 8 |
| VT_DATE (7) | DateVariant | fixed | `ReadInt64()` | 8 |
| VT_I8 (20) | Int64Variant | fixed | `ReadInt64()` | 8 |
| VT_UI8 (21) | Uint64Variant | fixed | `ReadInt64()` | 8 |
| VT_BSTR (8) | BStrVariant | string block | `ReadStringBlock()` | variable |
| VT_DISPATCH (9) | DispatchVariant | nested | size + string block + content | variable |
| VT_UNKNOWN (13) | UnknownVariant | nested | size + string block + content | variable |

## Test plan

- [x] All 4 new `VariantParsingTests` pass (previously failed with `WZPackageException`)
- [x] All 3 existing `KeystreamExpansionTests` continue to pass
- [x] Full test suite: 7 passed, 0 failed, 0 skipped

## Verification

Confirmed against the Duey2Test diagnostic framework, which implements the correct parsing table and successfully parses Map.wz with 0 unknown type errors (52,258 nodes, 52,264 strings):

| Variant | Duey2Test (correct) | Duey (before fix) | Duey (after fix) |
|---|---|---|---|
| BoolVariant | `ReadByte()` 1B | `ReadInt16()` 2B | `ReadByte()` 1B |
| CYVariant | `ReadInt64()` 8B | `ReadCompressedLong()` 1-9B | `ReadInt64()` 8B |
| Int64Variant | `ReadInt64()` 8B | `ReadCompressedLong()` 1-9B | `ReadInt64()` 8B |
| Uint64Variant | `ReadUInt64()` 8B | `ReadCompressedLong()` 1-9B | `ReadInt64()` 8B |

Fixes #6 