### PR TITLE
Fix WZPropertyCanvas.Resolve() for encrypted canvas nodes

### DIFF
--- a/src/Duey.Provider.WZ/Files/Extended/WZPropertyCanvas.cs
+++ b/src/Duey.Provider.WZ/Files/Extended/WZPropertyCanvas.cs
@@ -55,6 +55,7 @@ public class WZPropertyCanvas : WZPropertyDeferred<DataBitmap>
         var height = reader.ReadCompressedInt();
         var format = reader.ReadCompressedInt() switch
         {
+            0x001 => DataBitmapFormat.Rgba16,
             0x002 => DataBitmapFormat.Rgba32,
             0x201 => DataBitmapFormat.Rgba16,
             _ => DataBitmapFormat.Unknown
@@ -67,14 +68,37 @@ public class WZPropertyCanvas : WZPropertyDeferred<DataBitmap>
         var header = reader.ReadBytes(3);
         var data = reader.ReadBytes(length - 3);
 
+        width >>= scale;
+        height >>= scale;
+
+        if (header[1] != 0x78)
+        {
+            // Encrypted path: 8-byte preamble + XOR-encrypted raw deflate
+            //   data[0..3]  = constant magic [00 00 EE 32]
+            //   data[4..7]  = LE32 compressedSize
+            //   data[8..]   = XOR-encrypted raw deflate (no zlib wrapper)
+            if (data.Length < 8)
+                throw new InvalidDataException("Encrypted canvas preamble is too short.");
+            var compressedSize = BitConverter.ToInt32(data, 4);
+            if (compressedSize <= 0 || compressedSize > data.Length - 8)
+                throw new InvalidDataException(
+                    $"Encrypted canvas compressed size {compressedSize} is out of range.");
+
+            var payload = new byte[compressedSize];
+            Array.Copy(data, 8, payload, 0, compressedSize);
+            _cipher.Transform(payload);
+
+            using var encStream = new MemoryStream(payload, false);
+            using var deflate   = new DeflateStream(encStream, CompressionMode.Decompress);
+            using var output    = new MemoryStream();
+            deflate.CopyTo(output);
+            return new DataBitmap((ushort)width, (ushort)height, format, output.ToArray());
+        }
+
         using var stream0 = new MemoryStream(data, false);
         using var stream1 = new DeflateStream(stream0, CompressionMode.Decompress);
         using var stream2 = new MemoryStream();
-
-        width >>= scale;
-        height >>= scale;
         stream1.CopyTo(stream2);
-
         return new DataBitmap((ushort)width, (ushort)height, format, stream2.ToArray());
     }
 }

--- a/tests/Duey.Provider.WZ.Tests/CanvasChildrenTests.cs
+++ b/tests/Duey.Provider.WZ.Tests/CanvasChildrenTests.cs
@@ -8,6 +8,7 @@ using Duey.Provider.WZ.Files;
 using Duey.Provider.WZ.Files.Extended;
 using Duey.Provider.WZ.Types;
 using Xunit;
+using static Duey.Provider.WZ.Tests.WZTestHelpers;
 
 namespace Duey.Provider.WZ.Tests;
 
@@ -446,64 +447,8 @@ public class CanvasChildrenTests
         writer.Write((byte)0);                 // scale = 0
         writer.Write(0);                       // 4-byte skip
         writer.Write(totalLength);             // length (includes 3-byte header)
-        writer.Write(new byte[3]);             // 3-byte header (ignored by Resolve)
+        writer.Write(new byte[] { 0x00, 0x78, 0x9C }); // header: standard deflate path (header[1]=0x78)
         writer.Write(deflated);                // deflate-compressed pixel data
     }
 
-    private static void WriteCompressedInt(BinaryWriter writer, int value)
-    {
-        if (value >= -127 && value <= 127)
-        {
-            writer.Write((sbyte)value);
-        }
-        else
-        {
-            writer.Write((sbyte)(-128));
-            writer.Write(value);
-        }
     }
-
-    private static void WriteInlineStringBlock(BinaryWriter writer, string value, XORCipher cipher)
-    {
-        writer.Write((byte)0x00); // string block type: inline
-
-        if (string.IsNullOrEmpty(value))
-        {
-            writer.Write((sbyte)0);
-            return;
-        }
-
-        var plaintext = Encoding.ASCII.GetBytes(value);
-        writer.Write((sbyte)(-plaintext.Length));
-
-        var encrypted = new byte[plaintext.Length];
-        Buffer.BlockCopy(plaintext, 0, encrypted, 0, plaintext.Length);
-
-        cipher.Transform(encrypted);
-
-        byte mask = 0xAA;
-        for (var i = 0; i < encrypted.Length; i++)
-        {
-            encrypted[i] ^= mask;
-            mask++;
-        }
-
-        writer.Write(encrypted);
-    }
-
-    private static MemoryMappedFile CreateMemoryMappedFile(byte[] data)
-    {
-        var mmf = MemoryMappedFile.CreateNew(null, data.Length);
-        using var stream = mmf.CreateViewStream(0, data.Length, MemoryMappedFileAccess.Write);
-        stream.Write(data, 0, data.Length);
-        return mmf;
-    }
-
-    private static byte[] PadToMinimumSize(byte[] data, int minSize)
-    {
-        if (data.Length >= minSize) return data;
-        var padded = new byte[minSize];
-        Buffer.BlockCopy(data, 0, padded, 0, data.Length);
-        return padded;
-    }
-}

--- a/tests/Duey.Provider.WZ.Tests/EncryptedCanvasTests.cs
+++ b/tests/Duey.Provider.WZ.Tests/EncryptedCanvasTests.cs
@@ -1,0 +1,331 @@
+using System.IO.Compression;
+using System.IO.MemoryMappedFiles;
+using System.Text;
+using Duey.Abstractions;
+using Duey.Abstractions.Types;
+using Duey.Provider.WZ.Crypto;
+using Duey.Provider.WZ.Files;
+using Duey.Provider.WZ.Files.Extended;
+using Duey.Provider.WZ.Types;
+using Xunit;
+using static Duey.Provider.WZ.Tests.WZTestHelpers;
+
+namespace Duey.Provider.WZ.Tests;
+
+/// <summary>
+/// Tests for WZPropertyCanvas.Resolve() handling of GMS-encrypted canvas nodes
+/// (header[1] == 0x02) and the format 0x001 (BGRA4444) mapping.
+///
+/// Encrypted canvas binary layout after the "Canvas" block:
+///   [1B padding] [1B hasChildren]
+///   if hasChildren=1: [2B skip] [count CI] [count property entries]
+///   [CI: width] [CI: height] [CI: format] [1B: scale] [4B skip]
+///   [I32: totalLength]
+///   [byte: 0x00]              header[0]
+///   [byte: 0x02]              header[1] — discriminator for the encrypted path
+///   [byte: 0x00]              header[2]
+///   --- data (totalLength-3 bytes) ---
+///   [4 bytes: 00 00 EE 32]    constant magic
+///   [I32 LE: compressedSize]  byte count of the XOR-encrypted payload
+///   [compressedSize bytes]    XOR-encrypted raw deflate (no zlib wrapper)
+///
+/// Fix: detect header[1] != 0x78, parse 8-byte preamble, XOR-decrypt with _cipher,
+/// then feed to DeflateStream.
+///
+/// Secondary fix: format 0x001 (BGRA4444, 2 bytes/pixel) maps to DataBitmapFormat.Rgba16.
+/// </summary>
+public class EncryptedCanvasTests
+{
+    // ── Encrypted canvas decode tests (the fix) ──────────────────────────
+
+    /// <summary>
+    /// Encrypted canvas (header[1]=0x02) must decode pixel data correctly.
+    /// Before the fix, DeflateStream received the raw encrypted bytes and threw
+    /// InvalidDataException immediately.
+    /// </summary>
+    [Fact]
+    public void EncryptedCanvas_Resolve_DecodesPixelDataCorrectly()
+    {
+        var cipher = new XORCipher(WZImageIV.GMS);
+        const int w = 4, h = 4;
+        var expected = GeneratePixels(w * h * 2); // BGRA4444: 2 bytes/pixel
+        var data = BuildEncryptedCanvasData(cipher, w, h, 0x001, expected, hasChildren: false);
+
+        using var mmf = CreateMemoryMappedFile(data);
+        var canvas = new WZPropertyCanvas(mmf, cipher, start: 0, offset: 0, name: "canvas");
+
+        var bitmap = ((IDataProperty<DataBitmap>)canvas).Resolve();
+
+        Assert.Equal(w, bitmap.Width);
+        Assert.Equal(h, bitmap.Height);
+        Assert.Equal(DataBitmapFormat.Rgba16, bitmap.Format);
+        Assert.Equal(expected, bitmap.Data.ToArray());
+    }
+
+    /// <summary>
+    /// Decompressed byte count must equal exactly width × height × 2 for BGRA4444.
+    /// Verifies that no extra bytes are introduced or lost during the decrypt+decompress.
+    /// </summary>
+    [Fact]
+    public void EncryptedCanvas_Resolve_ExactPixelCountMatchesDimensions()
+    {
+        var cipher = new XORCipher(WZImageIV.GMS);
+        const int w = 8, h = 6;
+        var pixels = GeneratePixels(w * h * 2);
+        var data = BuildEncryptedCanvasData(cipher, w, h, 0x001, pixels, hasChildren: false);
+
+        using var mmf = CreateMemoryMappedFile(data);
+        var canvas = new WZPropertyCanvas(mmf, cipher, start: 0, offset: 0, name: "canvas");
+
+        var bitmap = ((IDataProperty<DataBitmap>)canvas).Resolve();
+
+        Assert.Equal(w * h * 2, bitmap.Data.Length);
+    }
+
+    /// <summary>
+    /// An encrypted canvas with hasChildren=1 must parse its sub-properties correctly
+    /// and remain resolvable — bitmap data follows the property block.
+    /// Combined regression for both the encrypted-path fix and the hasChildren fix.
+    /// </summary>
+    [Fact]
+    public void EncryptedCanvas_WithChildren_ResolvesAfterSubProperties()
+    {
+        var cipher = new XORCipher(WZImageIV.GMS);
+        const int w = 4, h = 4;
+        var pixels = GeneratePixels(w * h * 2);
+        var data = BuildEncryptedCanvasData(cipher, w, h, 0x001, pixels, hasChildren: true);
+
+        using var mmf = CreateMemoryMappedFile(data);
+        var canvas = new WZPropertyCanvas(mmf, cipher, start: 0, offset: 0, name: "canvas");
+
+        var children = canvas.Children.ToList();
+        Assert.Equal(2, children.Count);
+        Assert.Equal("x", children[0].Name);
+        Assert.Equal("y", children[1].Name);
+        Assert.Equal((long)w, ((IDataProperty<long>)children[0]).Resolve());
+        Assert.Equal((long)h, ((IDataProperty<long>)children[1]).Resolve());
+
+        var bitmap = ((IDataProperty<DataBitmap>)canvas).Resolve();
+
+        Assert.Equal(w, bitmap.Width);
+        Assert.Equal(h, bitmap.Height);
+        Assert.Equal(DataBitmapFormat.Rgba16, bitmap.Format);
+        Assert.Equal(w * h * 2, bitmap.Data.Length);
+    }
+
+    // ── Format 0x001 mapping tests ────────────────────────────────────────
+
+    /// <summary>
+    /// Format field 0x001 must map to DataBitmapFormat.Rgba16 (BGRA4444, 2 bytes/pixel).
+    /// Before the fix, 0x001 fell through to DataBitmapFormat.Unknown.
+    /// Uses the standard path (header[1]=0x78) to isolate the format mapping from the
+    /// encrypted-path fix.
+    /// </summary>
+    [Fact]
+    public void Format0x001_MapsToRgba16()
+    {
+        var cipher = new XORCipher(WZImageIV.GMS);
+        const int w = 4, h = 4;
+        var pixels = GeneratePixels(w * h * 2);
+        var data = BuildStandardCanvasData(cipher, w, h, 0x001, pixels);
+
+        using var mmf = CreateMemoryMappedFile(data);
+        var canvas = new WZPropertyCanvas(mmf, cipher, start: 0, offset: 0, name: "canvas");
+
+        var bitmap = ((IDataProperty<DataBitmap>)canvas).Resolve();
+
+        Assert.Equal(DataBitmapFormat.Rgba16, bitmap.Format);
+    }
+
+    /// <summary>
+    /// Regression: format 0x201 mapping to Rgba16 must remain unchanged.
+    /// </summary>
+    [Fact]
+    public void Format0x201_StillMapsToRgba16()
+    {
+        var cipher = new XORCipher(WZImageIV.GMS);
+        const int w = 4, h = 4;
+        var pixels = GeneratePixels(w * h * 2);
+        var data = BuildStandardCanvasData(cipher, w, h, 0x201, pixels);
+
+        using var mmf = CreateMemoryMappedFile(data);
+        var canvas = new WZPropertyCanvas(mmf, cipher, start: 0, offset: 0, name: "canvas");
+
+        var bitmap = ((IDataProperty<DataBitmap>)canvas).Resolve();
+
+        Assert.Equal(DataBitmapFormat.Rgba16, bitmap.Format);
+    }
+
+    // ── Standard path regression test ────────────────────────────────────
+
+    /// <summary>
+    /// Standard canvas (header[1]=0x78) must still decode correctly after the
+    /// encrypted-path branch was added. Output must be byte-identical to before.
+    /// </summary>
+    [Fact]
+    public void StandardCanvas_Resolve_StillDecodesCorrectly()
+    {
+        var cipher = new XORCipher(WZImageIV.GMS);
+        const int w = 4, h = 4;
+        var expected = GeneratePixels(w * h * 4); // Rgba32: 4 bytes/pixel
+        var data = BuildStandardCanvasData(cipher, w, h, 0x002, expected);
+
+        using var mmf = CreateMemoryMappedFile(data);
+        var canvas = new WZPropertyCanvas(mmf, cipher, start: 0, offset: 0, name: "canvas");
+
+        var bitmap = ((IDataProperty<DataBitmap>)canvas).Resolve();
+
+        Assert.Equal(w, bitmap.Width);
+        Assert.Equal(h, bitmap.Height);
+        Assert.Equal(DataBitmapFormat.Rgba32, bitmap.Format);
+        Assert.Equal(expected, bitmap.Data.ToArray());
+    }
+
+    // ── Binary data builders ──────────────────────────────────────────────
+
+    /// <summary>
+    /// Generates a deterministic non-trivial pixel byte sequence to avoid
+    /// compressor short-circuits on all-zero or constant data.
+    /// </summary>
+    private static byte[] GeneratePixels(int count)
+    {
+        var pixels = new byte[count];
+        for (var i = 0; i < count; i++)
+            pixels[i] = (byte)((i * 7 + 13) % 256);
+        return pixels;
+    }
+
+    /// <summary>
+    /// Builds a full canvas binary blob using the encrypted path (header[1]=0x02).
+    /// Layout:
+    ///   [padding] [hasChildren]
+    ///   if hasChildren: [2B skip] [count=2] [prop "x"=width] [prop "y"=height]
+    ///   [CI width] [CI height] [CI format] [scale] [4B skip]
+    ///   [I32 totalLength] [00 02 00] [magic] [LE32 size] [XOR-encrypted deflate]
+    /// </summary>
+    private static byte[] BuildEncryptedCanvasData(
+        XORCipher cipher, int width, int height, int format, byte[] pixels, bool hasChildren)
+    {
+        using var ms = new MemoryStream();
+        using var writer = new BinaryWriter(ms);
+
+        writer.Write((byte)0x00);                            // padding
+        writer.Write(hasChildren ? (byte)0x01 : (byte)0x00); // hasChildren
+
+        if (hasChildren)
+        {
+            writer.Write((short)0); // 2-byte skip
+            writer.Write((sbyte)2); // property count = 2
+
+            WriteInlineStringBlock(writer, "x", cipher);
+            writer.Write((byte)WZVariantType.Int32Variant);
+            WriteCompressedInt(writer, width);
+
+            WriteInlineStringBlock(writer, "y", cipher);
+            writer.Write((byte)WZVariantType.Int32Variant);
+            WriteCompressedInt(writer, height);
+        }
+
+        WriteEncryptedBitmapSection(writer, cipher, width, height, format, pixels);
+
+        return PadToMinimumSize(ms.ToArray(), 512);
+    }
+
+    /// <summary>
+    /// Builds a full canvas binary blob using the standard path (header[1]=0x78).
+    /// Layout:
+    ///   [padding] [hasChildren=0]
+    ///   [CI width] [CI height] [CI format] [scale] [4B skip]
+    ///   [I32 totalLength] [00 78 9C] [raw deflate]
+    /// </summary>
+    private static byte[] BuildStandardCanvasData(
+        XORCipher cipher, int width, int height, int format, byte[] pixels)
+    {
+        using var ms = new MemoryStream();
+        using var writer = new BinaryWriter(ms);
+
+        writer.Write((byte)0x00); // padding
+        writer.Write((byte)0x00); // hasChildren = false
+
+        WriteStandardBitmapSection(writer, width, height, format, pixels);
+
+        return PadToMinimumSize(ms.ToArray(), 512);
+    }
+
+    /// <summary>
+    /// Writes the bitmap fields for the encrypted path:
+    ///   [CI width] [CI height] [CI format] [byte scale=0] [4B skip]
+    ///   [I32 totalLength] [byte 0x00] [byte 0x02] [byte 0x00]
+    ///   [4B magic: 00 00 EE 32] [I32 LE compressedSize] [encrypted deflate]
+    ///
+    /// XOR-encryption uses the same cipher instance that Resolve() will use to
+    /// decrypt — Transform() is always applied from key offset 0.
+    /// </summary>
+    private static void WriteEncryptedBitmapSection(
+        BinaryWriter writer, XORCipher cipher, int width, int height, int format, byte[] pixels)
+    {
+        byte[] deflated;
+        using (var deflateMs = new MemoryStream())
+        {
+            using (var deflater = new DeflateStream(deflateMs, CompressionMode.Compress, leaveOpen: true))
+                deflater.Write(pixels, 0, pixels.Length);
+            deflated = deflateMs.ToArray();
+        }
+
+        // XOR-encrypt: cipher.Transform always starts from key offset 0,
+        // so this is the exact inverse of the Transform call in Resolve().
+        var encrypted = new byte[deflated.Length];
+        Buffer.BlockCopy(deflated, 0, encrypted, 0, deflated.Length);
+        cipher.Transform(encrypted);
+
+        // Preamble: magic [00 00 EE 32] + LE32 compressedSize
+        var data = new byte[8 + encrypted.Length];
+        data[0] = 0x00; data[1] = 0x00; data[2] = 0xEE; data[3] = 0x32;
+        var sizeBytes = BitConverter.GetBytes(encrypted.Length);
+        Buffer.BlockCopy(sizeBytes, 0, data, 4, 4);
+        Buffer.BlockCopy(encrypted, 0, data, 8, encrypted.Length);
+
+        var totalLength = 3 + data.Length; // 3-byte header + data
+
+        WriteCompressedInt(writer, width);
+        WriteCompressedInt(writer, height);
+        WriteCompressedInt(writer, format);
+        writer.Write((byte)0);    // scale = 0
+        writer.Write(0);          // 4-byte skip
+        writer.Write(totalLength);
+        writer.Write((byte)0x00); // header[0]
+        writer.Write((byte)0x02); // header[1] = 0x02 → encrypted path
+        writer.Write((byte)0x00); // header[2]
+        writer.Write(data);
+    }
+
+    /// <summary>
+    /// Writes the bitmap fields for the standard path:
+    ///   [CI width] [CI height] [CI format] [byte scale=0] [4B skip]
+    ///   [I32 totalLength] [byte 0x00] [byte 0x78] [byte 0x9C] [raw deflate]
+    /// </summary>
+    private static void WriteStandardBitmapSection(
+        BinaryWriter writer, int width, int height, int format, byte[] pixels)
+    {
+        byte[] deflated;
+        using (var deflateMs = new MemoryStream())
+        {
+            using (var deflater = new DeflateStream(deflateMs, CompressionMode.Compress, leaveOpen: true))
+                deflater.Write(pixels, 0, pixels.Length);
+            deflated = deflateMs.ToArray();
+        }
+
+        var totalLength = 3 + deflated.Length;
+
+        WriteCompressedInt(writer, width);
+        WriteCompressedInt(writer, height);
+        WriteCompressedInt(writer, format);
+        writer.Write((byte)0);    // scale = 0
+        writer.Write(0);          // 4-byte skip
+        writer.Write(totalLength);
+        writer.Write((byte)0x00); // header[0]
+        writer.Write((byte)0x78); // header[1] = 0x78 → standard path
+        writer.Write((byte)0x9C); // header[2]
+        writer.Write(deflated);
+    }
+    }

--- a/tests/Duey.Provider.WZ.Tests/VariantParsingTests.cs
+++ b/tests/Duey.Provider.WZ.Tests/VariantParsingTests.cs
@@ -4,6 +4,7 @@ using Duey.Provider.WZ.Crypto;
 using Duey.Provider.WZ.Files;
 using Duey.Provider.WZ.Types;
 using Xunit;
+using static Duey.Provider.WZ.Tests.WZTestHelpers;
 
 namespace Duey.Provider.WZ.Tests;
 
@@ -191,50 +192,4 @@ public class VariantParsingTests
 
         return PadToMinimumSize(ms.ToArray(), 256);
     }
-
-    /// <summary>
-    /// Writes an inline string block (type 0x00) with ASCII encoding.
-    /// Encrypts the string content using the same XOR mask + cipher pipeline
-    /// that WZReader.ReadString/ReadStringASCII uses for decryption.
-    /// </summary>
-    private static void WriteInlineStringBlock(BinaryWriter writer, string value, XORCipher cipher)
-    {
-        writer.Write((byte)0x00); // string block type: inline
-
-        if (string.IsNullOrEmpty(value))
-        {
-            writer.Write((sbyte)0); // length = 0 → empty string
-            return;
-        }
-
-        var plaintext = Encoding.ASCII.GetBytes(value);
-        writer.Write((sbyte)(-plaintext.Length)); // negative length = ASCII
-
-        // Encrypt: reverse of WZReader decryption pipeline
-        // Decryption: raw → XOR mask (0xAA+i) → cipher XOR keystream → plaintext
-        // Encryption: plaintext → cipher XOR keystream → XOR mask (0xAA+i) → raw
-        var encrypted = new byte[plaintext.Length];
-        Buffer.BlockCopy(plaintext, 0, encrypted, 0, plaintext.Length);
-
-        cipher.Transform(encrypted);
-
-        byte mask = 0xAA;
-        for (var i = 0; i < encrypted.Length; i++)
-        {
-            encrypted[i] ^= mask;
-            mask++;
-        }
-
-        writer.Write(encrypted);
     }
-
-    private static byte[] PadToMinimumSize(byte[] data, int minSize)
-    {
-        if (data.Length >= minSize)
-            return data;
-
-        var padded = new byte[minSize];
-        Buffer.BlockCopy(data, 0, padded, 0, data.Length);
-        return padded;
-    }
-}

--- a/tests/Duey.Provider.WZ.Tests/WZTestHelpers.cs
+++ b/tests/Duey.Provider.WZ.Tests/WZTestHelpers.cs
@@ -1,0 +1,83 @@
+using System.IO.MemoryMappedFiles;
+using System.Text;
+using Duey.Provider.WZ.Crypto;
+
+namespace Duey.Provider.WZ.Tests;
+
+/// <summary>
+/// Shared binary-building helpers used across all WZ test classes.
+/// </summary>
+internal static class WZTestHelpers
+{
+    /// <summary>
+    /// Wraps a byte array in an anonymous memory-mapped file for use as a WZ view.
+    /// </summary>
+    internal static MemoryMappedFile CreateMemoryMappedFile(byte[] data)
+    {
+        var mmf = MemoryMappedFile.CreateNew(null, data.Length);
+        using var stream = mmf.CreateViewStream(0, data.Length, MemoryMappedFileAccess.Write);
+        stream.Write(data, 0, data.Length);
+        return mmf;
+    }
+
+    /// <summary>
+    /// Writes a WZ inline string block (type 0x00) with ASCII encoding.
+    ///
+    /// Encoding pipeline (reverse of WZReader decryption):
+    ///   plaintext → cipher XOR keystream → XOR incrementing mask (0xAA+i) → raw bytes
+    /// </summary>
+    internal static void WriteInlineStringBlock(BinaryWriter writer, string value, XORCipher cipher)
+    {
+        writer.Write((byte)0x00); // string block type: inline
+
+        if (string.IsNullOrEmpty(value))
+        {
+            writer.Write((sbyte)0);
+            return;
+        }
+
+        var plaintext = Encoding.ASCII.GetBytes(value);
+        writer.Write((sbyte)(-plaintext.Length)); // negative length = ASCII encoding
+
+        var encrypted = new byte[plaintext.Length];
+        Buffer.BlockCopy(plaintext, 0, encrypted, 0, plaintext.Length);
+        cipher.Transform(encrypted);
+
+        byte mask = 0xAA;
+        for (var i = 0; i < encrypted.Length; i++)
+        {
+            encrypted[i] ^= mask;
+            mask++;
+        }
+
+        writer.Write(encrypted);
+    }
+
+    /// <summary>
+    /// Writes a WZ compressed integer:
+    ///   values in [-127, 127] → 1 byte (sbyte)
+    ///   values outside that range → 0x80 sentinel + 4-byte LE int
+    /// </summary>
+    internal static void WriteCompressedInt(BinaryWriter writer, int value)
+    {
+        if (value >= -127 && value <= 127)
+            writer.Write((sbyte)value);
+        else
+        {
+            writer.Write((sbyte)(-128));
+            writer.Write(value);
+        }
+    }
+
+    /// <summary>
+    /// Pads a byte array to at least <paramref name="minSize"/> bytes so that
+    /// memory-mapped view streams do not read past the end of the buffer.
+    /// </summary>
+    internal static byte[] PadToMinimumSize(byte[] data, int minSize)
+    {
+        if (data.Length >= minSize) return data;
+        var padded = new byte[minSize];
+        Buffer.BlockCopy(data, 0, padded, 0, data.Length);
+        return padded;
+    }
+}


### PR DESCRIPTION
# Problem

`WZPropertyCanvas.Resolve()` fails with `InvalidDataException: The archive entry was
compressed using an unsupported compression method` for canvas nodes that use the
GMS encrypted storage path. These nodes represent the majority of mob sprite frames
in GMS v95 clients — 1,432+ canvas nodes in `Mob.wz` alone are unreachable.

A secondary issue: format `0x001` (BGRA4444) is absent from the format switch and
falls to `DataBitmapFormat.Unknown`, producing incorrect output even when the
decompression step would otherwise succeed.

## Root cause

The current `Resolve()` always feeds the pixel data bytes directly to `DeflateStream`.
For the encrypted path (`header[1] == 0x02`), those bytes are:

```
[4 bytes: 00 00 EE 32]    constant magic
[4 bytes: LE32 size]      byte count of the encrypted payload
[size bytes]              XOR-encrypted raw deflate (GMS AES keystream, key offset 0)
```

`DeflateStream` receives `0x00` as its first byte and immediately rejects the stream.
The correct approach is to detect `header[1] != 0x78`, parse the 8-byte preamble,
XOR-decrypt the payload using the canvas node's existing `_cipher`, and feed the
decrypted bytes to `DeflateStream`.

The format omission (`0x001`) is a straightforward addition to the same switch
expression.

## Changes

### `WZPropertyCanvas.cs`

**Format switch** — add `0x001 => DataBitmapFormat.Rgba16`.

**Resolve() body** — after reading `length`, `header`, and `data`:

1. Check `header[1]`. If `== 0x78`: existing path unchanged (raw deflate in `data`).
2. If `!= 0x78` (encrypted path):
   - Validate `data.Length >= 8` and read `compressedSize = BitConverter.ToInt32(data, 4)`.
   - Validate `compressedSize > 0 && compressedSize <= data.Length - 8`.
   - Copy `data[8..8+compressedSize]` into a new `byte[]`, call `_cipher.Transform()`
     in-place.
   - Decompress with `DeflateStream` (no zlib wrapper) and return the `DataBitmap`.

`_cipher` is already available as the inherited field. No new constructor parameters,
fields, or dependencies required.

No changes to `WZPropertyFile`, `WZPropertyDeferred`, or any other class.

## Testing

### New test file: `EncryptedCanvasTests.cs`

Follows the synthetic binary data pattern established in `CanvasChildrenTests.cs`.
All tests use `XORCipher(WZImageIV.GMS)` to encrypt test payloads — the same cipher
used in production.

**Encrypted canvas decode (the fix):**
- `EncryptedCanvas_Resolve_DecodesPixelDataCorrectly` — BGRA4444 canvas with XOR-
  encrypted raw deflate; `Resolve()` returns a `DataBitmap` with correct `width`,
  `height`, `Format = Rgba16`, and pixel bytes matching the original before encryption
- `EncryptedCanvas_Resolve_ExactPixelCountMatchesDimensions` — decompressed length
  equals exactly `width × height × 2` for BGRA4444
- `EncryptedCanvas_WithChildren_ResolvesAfterSubProperties` — encrypted canvas that
  also has `hasChildren=1`; children parse correctly and bitmap resolves after them

**Format 0x001 mapping:**
- `Format0x001_MapsToRgba16` — canvas with format `0x001` and standard deflate path
  produces `Format = Rgba16` (not `Unknown`)
- `Format0x201_StillMapsToRgba16` — regression: `0x201` mapping unchanged

**Standard path regression:**
- `StandardCanvas_Resolve_StillDecodesCorrectly` — `header[1]=0x78` canvas follows
  the existing path; output is byte-identical to before this change

### Synthetic binary builder for encrypted canvases

```
BuildEncryptedCanvasData(cipher, width, height, format):
  1. Generate pixel data: width × height × 2 bytes (BGRA4444)
  2. Compress with DeflateStream (raw, no zlib wrapper) → deflated[]
  3. XOR deflated[] with cipher.Transform() → encrypted[]
  4. preamble = [00 00 EE 32] + LE32(encrypted.Length)
  5. data = preamble + encrypted
  6. totalLength = 3 + data.Length
  7. Write: [padding 0x00] [hasChildren 0x00]
           [CI: width] [CI: height] [CI: format=0x001] [byte: scale=0] [4 zero bytes]
           [I32: totalLength] [header: 00 02 00] [data]
```

### Integration verification (done externally, not in unit tests)

Verified against GMS v95 `Mob.wz` using the Duey2Test reflection harness before
submitting this PR:
- All format=0x001 encrypted canvases produce exact `width × height × 2` decompressed
  byte counts (0 failures across all sampled canvases)
- Full export: 7,978 PNG files from all mob entries including snail family
  (`0100100.img`, `0100101.img`, etc.) which were previously entirely blank

## Relationship to childless-canvas fix

This PR is independent of the `WZPropertyCanvas.Children` childless-canvas fix
(see `ISSUE-childless-canvas.md`). Both can be applied in either order. The two fixes
affect completely separate methods (`Resolve()` here, `Children` there) and target
entirely different canvas classes (encrypted mob sprites here, childless minimap leaf
nodes there).

fixes #10 